### PR TITLE
[Fix] Resolve npm ERESOLVE error in dependencies. React version 18.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-svg-buttons",
   "description": "Configurable animated SVG buttons for react",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "lib",
   "author": {
     "name": "Raphaël Benitte"
@@ -27,20 +27,20 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "prop-types": "^15.5.10",
-    "react-motion": "^0.5.0"
+    "prop-types": "^15.8.1",
+    "react-motion": "^0.5.2"
   },
   "devDependencies": {
-    "babel-cli": "6.11.4",
-    "babel-core": "6.11.4",
+    "babel-cli": "6.26.0",
+    "babel-core": "6.26.3",
     "babel-preset-es2015": "6.9.0",
-    "babel-preset-react": "6.11.1",
-    "babel-preset-stage-2": "6.11.0",
-    "prettier": "^1.5.3",
-    "react": "^15.4.1"
+    "babel-preset-react": "6.24.1",
+    "babel-preset-stage-2": "6.24.1",
+    "prettier": "^3.2.4",
+    "react": "^18.2.0"
   },
   "peerDependencies": {
-    "react": "^15.4.1"
+    "react": "^18.2.0"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
__Before the fix (current behavior)__

 npm ERR! trying to install `react-svg-buttons`

  ```sh
  cristian@localhost:~/repos/quick-test$ npm install react-svg-buttons
  npm ERR! code ERESOLVE
  npm ERR! ERESOLVE unable to resolve dependency tree
  npm ERR! 
  npm ERR! While resolving: quick-test@0.0.0
  npm ERR! Found: react@18.2.0
  npm ERR! node_modules/react
  npm ERR!   react@"^18.2.0" from the root project
  npm ERR! 
  npm ERR! Could not resolve dependency:
  npm ERR! peer react@"^15.4.1" from react-svg-buttons@0.4.0
  npm ERR! node_modules/react-svg-buttons
  npm ERR!   react-svg-buttons@"*" from the root project
  npm ERR! 
  npm ERR! Fix the upstream dependency conflict, or retry
  npm ERR! this command with --force or --legacy-peer-deps
  npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
  npm ERR! 
  npm ERR! 
  npm ERR! For a full report see:
  npm ERR! /home/cristian/.npm/_logs/2024-01-20T16_56_02_533Z-eresolve-report.txt

  npm ERR! A complete log of this run can be found in: /home/cristian/.npm/_logs/2024-01-20T16_56_02_533Z-debug-0.log
  ```

__Changes made__
- [x] Updated all dependencies on package.json to their latest versions. ("react": "^18.2.0")
```sh
npx npm-check-updates -u
npm install
```
```json
  "dependencies": {
    "prop-types": "^15.8.1",
    "react-motion": "^0.5.2"
  },
  "devDependencies": {
    "babel-cli": "6.26.0",
    "babel-core": "6.26.3",
    "babel-preset-es2015": "6.9.0",
    "babel-preset-react": "6.24.1",
    "babel-preset-stage-2": "6.24.1",
    "prettier": "^3.2.4",
    "react": "^18.2.0"
  },
```
- [x] Updated peerDependencies to "react": "^18.2.0".
```json
  "peerDependencies": {
    "react": "^18.2.0"
  },
```

__Build and test__

__Build__

```sh
npm run build
npm pack
```


__Test after the fix__

```sh
cristian@localhost:~/repos/quick-test$ npm install ../react-svg-buttons-improved/react-svg-buttons-0.5.0.tgz 
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: react-motion@0.5.2
npm WARN Found: react@18.2.0
npm WARN node_modules/react
npm WARN   peer react@"^18.2.0" from react-dom@18.2.0
npm WARN   node_modules/react-dom
npm WARN     react-dom@"^18.2.0" from the root project
npm WARN   2 more (the root project, react-svg-buttons)
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer react@"^0.14.9 || ^15.3.0 || ^16.0.0" from react-motion@0.5.2
npm WARN node_modules/react-motion
npm WARN   react-motion@"^0.5.2" from react-svg-buttons@0.5.0
npm WARN   node_modules/react-svg-buttons
npm WARN 
npm WARN Conflicting peer dependency: react@16.14.0
npm WARN node_modules/react
npm WARN   peer react@"^0.14.9 || ^15.3.0 || ^16.0.0" from react-motion@0.5.2
npm WARN   node_modules/react-motion
npm WARN     react-motion@"^0.5.2" from react-svg-buttons@0.5.0
npm WARN     node_modules/react-svg-buttons

up to date, audited 277 packages in 1s

97 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```
Test with a basic Vite/React app

![Test buttons Vite/React](https://github.com/plouc/react-svg-buttons/assets/77868316/ab0921e4-ea69-47e1-8009-f3b16aa9edaf)
